### PR TITLE
Fix infinite loop

### DIFF
--- a/scripts/wmic
+++ b/scripts/wmic
@@ -109,6 +109,8 @@ class WmiClient(object):
             except Exception, e:
                 if e.get_error_code() != wmi.WBEMSTATUS.WBEM_S_FALSE:
                     raise
+                else:
+                    break
 
     def query_and_print(self, wql, **kwargs):
         """


### PR DESCRIPTION
queryObject.Next raises a WBEM_S_FALSE exception in case of no more elements. The problem is now, that we catch this exception and only allow to break out of the loop in case of any other exception. This causes the while loop to run forever.
